### PR TITLE
Add support for category intro text

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,6 +12,9 @@
 	<div class="extra-pagination">
 	    {{ partial "pagination.html" .}}
 	</div>
+  {{ with .Content }}
+    <div class="microblog_category_intro">{{ . }}</div>
+  {{ end }}
   {{ range $paginator.Pages  }}
   {{ .Render "summary"  }}
   {{ end  }}

--- a/static/assets/css/screen.css
+++ b/static/assets/css/screen.css
@@ -210,6 +210,12 @@ dl dd {
     margin-bottom: 1em
 }
 
+.microblog_category_intro {
+    border-bottom: solid 1px lightgray;
+    padding-bottom: 15px;
+    margin-bottom: 30px;
+}
+
 /*	==========================================================================
 	Blog header
 	========================================================================== */


### PR DESCRIPTION
A first take on supporting category intro text, using the same light gray separator that appears beneath the category list on the archive page.
